### PR TITLE
Fix leak removing reaper

### DIFF
--- a/src/Network/StatsD/Datadog.hs
+++ b/src/Network/StatsD/Datadog.hs
@@ -374,7 +374,10 @@ send Dummy _ = return ()
 {-# INLINEABLE send #-}
 
 write :: Handle -> Utf8Builder () -> IO ()
-write h b = (B.hPut h . runUtf8Builder $ b >> appendChar7 '\n') `catch` handle
+write h b = (B.hPut h . runUtf8Builder $ b >> appendChar7 '\n') `catch` ignoreIO
 
-handle :: IOException -> IO ()
-handle err = hPutStrLn stderr $ "datadog:Datadog.hs: " `mappend` show err
+-- | Ignoring IOException from UDP socket write operation. UDP is
+-- lossy anyway. Not trying to handle as metric write rate can be high
+-- and this function is called a lot.
+ignoreIO :: IOException -> IO ()
+ignoreIO = const $ pure ()


### PR DESCRIPTION
This version removes reaper thread entirely. IOExceptions ignored so as not to blow up caller (before, they were also not thrown to the caller, but killed the reaper thread).

Relying on atomicity of hPut.

Perf good. Getting 50K metrics/second with 4 writer threads, constant memory use, whether statsd is up or down (hitting IOException path). Statsd says most metrics transfer (I suspect any loss is just nature of UDP).

Alternative: https://github.com/TaktInc/datadog/pull/4

Steps to reproduce the problem: #2 

